### PR TITLE
Fix: [SoloudAudio.mod] Reset audio stream position on each load attempt

### DIFF
--- a/soloudaudio.mod/soloudaudio.bmx
+++ b/soloudaudio.mod/soloudaudio.bmx
@@ -227,19 +227,24 @@ Type TSoloudSound Extends TSound
 	End Function
 	
 	Function TryLoadSound:TSLLoadableAudioSource(stream:TStream, flags:Int)
+		If Not stream Then Return Null
+
 		Local sound:TSLLoadableAudioSource
+		Local loader:TAudioSourceLoader = audio_loaders
+
+		Local pos:Int = stream.Pos()
 		
-		While audio_loaders
-			sound = audio_loaders.LoadAudioSource(stream, flags)
-			If sound Then
-				Return sound
-			End If
+		While loader
+			'reset to initial position for each loader attempt
+			stream.Seek(pos)
 			
-			audio_loaders = audio_loaders._succ
+			sound = loader.LoadAudioSource(stream, flags)
+			If sound Then Exit
+			
+			loader = loader._succ
 		Wend
 		
 		Return sound
-		
 	End Function
 	
 End Type


### PR DESCRIPTION
Reset a streams position each before trying to load the file.

This avoids the issue if a previous loader just advanced in the stream without resetting it.
The commit also avoids iterating over the original `audio_loaders` as this would break thread-safety.


Closes #15 
Closes #16 
